### PR TITLE
remove sa_handle

### DIFF
--- a/src/fiber.c
+++ b/src/fiber.c
@@ -311,7 +311,6 @@ static void k_thread_exec_func(void *arg UNUSED)
 
     /* timer and signal for user-level thread scheduling */
     struct sigaction sched_handler = {
-        .sa_flags = SA_SIGINFO,
         .sa_handler = &schedule, /* set signal handler to call scheduler */
     };
     sigaction(SIGPROF, &sched_handler, NULL);


### PR DESCRIPTION
Passing the flag `SA_SIGINFO` means that we use `sa_sigaction` to handle the interrupt instead of .`sa_handler`. Although it seems to work well in the program, it may lead to some misunderstanding.