### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ thread (ULT) and Linux native thread (or kernel-level thread, KLT).
 * Preemptive user-level threads
 * Familiar threading concepts are available
   - Mutexes
-  - Condition varialbles
+  - Condition variables
 
 ## Implementation Details
 


### PR DESCRIPTION
Thank you for your feedback on the previous pull request.
 I understand that I should not modify the license declaration in README.md.